### PR TITLE
Add Jest tests for invoice parser

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,33 @@
+const { extractInvoiceFields, parseText } = require('../src/index');
+const Tesseract = require('tesseract.js');
+
+jest.mock('tesseract.js');
+
+describe('extractInvoiceFields', () => {
+  it('parses fields from recognized text', async () => {
+    const sampleText = `Invoice INV-123\nDate: 2025-01-22\nAmount: 1234.56\nVendor: Supplier Name`;
+    Tesseract.recognize.mockResolvedValue({ data: { text: sampleText } });
+
+    const result = await extractInvoiceFields('dummy-path');
+
+    expect(result).toEqual({
+      invoiceNumber: 'INV-123',
+      date: '2025-01-22',
+      amount: 1234.56,
+      vendor: 'Supplier Name',
+    });
+  });
+});
+
+describe('parseText', () => {
+  it('extracts fields directly from text', () => {
+    const sampleText = `Invoice INV-123\nDate: 2025-01-22\nAmount: 1234.56\nVendor: Supplier Name`;
+    const result = parseText(sampleText);
+    expect(result).toEqual({
+      invoiceNumber: 'INV-123',
+      date: '2025-01-22',
+      amount: 1234.56,
+      vendor: 'Supplier Name',
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "invoice-ocr-app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,21 @@
+const Tesseract = require('tesseract.js');
+
+function parseText(text) {
+  const invoiceNumberMatch = text.match(/INV-\d+/);
+  const dateMatch = text.match(/\d{4}-\d{2}-\d{2}/);
+  const amountMatch = text.match(/\d+\.\d{2}/);
+  const vendorMatch = text.match(/Vendor:\s*(.+)/i);
+  return {
+    invoiceNumber: invoiceNumberMatch ? invoiceNumberMatch[0] : null,
+    date: dateMatch ? dateMatch[0] : null,
+    amount: amountMatch ? parseFloat(amountMatch[0]) : null,
+    vendor: vendorMatch ? vendorMatch[1].trim() : null,
+  };
+}
+
+async function extractInvoiceFields(imagePath) {
+  const { data: { text } } = await Tesseract.recognize(imagePath, 'eng');
+  return parseText(text);
+}
+
+module.exports = { extractInvoiceFields, parseText };


### PR DESCRIPTION
## Summary
- initialize a Node project with Jest
- add invoice parsing utilities
- test invoice field extraction with mocked Tesseract.js

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef7d19ce483208f96be1ae49675cd